### PR TITLE
Allow separate height and distribution seeds for a resource

### DIFF
--- a/mort/mineralvein/OreVein.java
+++ b/mort/mineralvein/OreVein.java
@@ -14,6 +14,7 @@ import org.bukkit.block.Biome;
 public class OreVein {
         public MVMaterial mat;
         public int seed;
+        public int heightSeed;
         public double density;
         public double maxSpan;
         public double densBonus;
@@ -35,6 +36,7 @@ public class OreVein {
                 ret[i] = new OreVein();
                 ret[i].mat = new MVMaterial( nd.getString("sec.block","0") );
                 ret[i].seed = nd.getInt("sec.seed", 6516);
+                ret[i].heightSeed = nd.getInt("sec.heightSeed", ret[i].seed);
                 ret[i].density = nd.getDouble("sec.density", 1);
                 ret[i].maxSpan = nd.getDouble("sec.thickness", 5);
                 ret[i].densBonus = nd.getDouble("sec.densityBonus", 0);

--- a/mort/mineralvein/VeinPopulator.java
+++ b/mort/mineralvein/VeinPopulator.java
@@ -35,7 +35,7 @@ public class VeinPopulator extends BlockPopulator{
             noiseGen = new NoiseGenerator[ores.length*2];
             for(int i=0;i<ores.length;i++){
                 noiseGen[i*2] = new SimplexNoiseGenerator( w.getSeed() * ores[i].seed );
-                noiseGen[i*2+1] = new SimplexNoiseGenerator( w.getSeed() * ores[i].seed * 5646468L );
+                noiseGen[i*2+1] = new SimplexNoiseGenerator( w.getSeed() * ores[i].heightSeed * 5646468L );
             }
             noise.put(w, noiseGen);
             }

--- a/mort/mineralvein/VeinPopulator.java
+++ b/mort/mineralvein/VeinPopulator.java
@@ -34,8 +34,8 @@ public class VeinPopulator extends BlockPopulator{
         if( !noise.containsKey(w) ){
             noiseGen = new NoiseGenerator[ores.length*2];
             for(int i=0;i<ores.length;i++){
-                noiseGen[i*2] = new SimplexNoiseGenerator( w.getSeed() * ores[i].seed );
-                noiseGen[i*2+1] = new SimplexNoiseGenerator( w.getSeed() * ores[i].heightSeed * 5646468L );
+                noiseGen[i*2] = new SimplexNoiseGenerator( w.getSeed() * ores[i].heightSeed );
+                noiseGen[i*2+1] = new SimplexNoiseGenerator( w.getSeed() * ores[i].seed * 5646468L );
             }
             noise.put(w, noiseGen);
             }


### PR DESCRIPTION
This fix is to close a theoretical way of reverse-engineering the seed that I've been thinking through. It comes from the distribution noise map seed being derived from the 32 bit height noise map seed, and a lot of information about the height noise map being possible to see. This is based on some rough tests with made-up data. I haven't tested with real data and reversed a real seed. This comes from observing a series of ore blocks' locations, and filtering to seeds that give a non-zero chance of that block being there. A brute force search of 32 bits is quite feasible with a home PC today.

With sensible parameters, we have a high probability within a vein of having some blocks at both the highest and lowest possible points for the height noise map being used. A block being present at a location lets us rule out all height maps where the centre is more than the max span away from that height at that point. It may not sound like much, but by getting both the highest and lowest blocks in a vein we have a good idea of what the height is at that point. Measuring top and bottom blocks of vein should limit us to a couple of percent of possible seeds for a vein at the average height. As long as good random numbers are used, different veins should limit seeds independently and allow us to reverse the seed from 6 to 7 veins of a resource if we know or can guess the other parameters. If there's doubt in other parameters, we may have to search with a few different alternatives and use a few more veins. This increases the search space and effort, but should still be feasible.

Once the height map seed is reversed, the distribution map seed can be found from it by multiplying. This would then give the location of every other vein of that resource.

This fix doesn't prevent the height map from being reversed, but does allow the distribution map to use a different seed. Similar efforts on reversing the distribution map have led to a lot less success - less information visible in each vein and much more recording needed (blocks around the rim of the vein as opposed to top & bottom of the middle). By default the height map will use the same seed as it does now, but it can be changed in the config for people starting from a fresh map.
